### PR TITLE
feat(EWT-1383): add form for defining model asset

### DIFF
--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -4,10 +4,10 @@ from fasthtml.common import *
 ### HTML Templates ###
 ######################
 
-def inputTemplate(label, name, val, error_msg=None, input_type='text'):
+def inputTemplate(label, name, val, error_msg=None, input_type='text', canValidateInline=True):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
                Label(label),
-               Input(name=name,type=input_type,value=f'{val}',hx_post=f'/{name.lower()}', style="width: 400px; text-align: center;"),
+               Input(name=name,type=input_type,value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style="width: 400px; text-align: center;"),
                Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
 def inputListTemplate(label, name, values=[None, None, None, None], error_msg=None, input_type='number'):
@@ -34,22 +34,22 @@ def mk_checkbox(options):
         *[Div(CheckboxX(id=option, label=option), style="width: 100%;") for option in options]
     )
 
-def selectEnumTemplate(label, options, name, error_msg=None):
+def selectEnumTemplate(label, options, name, error_msg=None, canValidateInline=True):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
         Label(label),
         Select(
             *mk_opts(name, options),
             name=name,
-            hx_post=f'/{name.lower()}'),
+            hx_post=f'/{name.lower()}' if canValidateInline else None),
         Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
-def selectCheckboxTemplate(label, options, name, error_msg=None):
+def selectCheckboxTemplate(label, options, name, error_msg=None, canValidateInline=True):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
         Label(label),
         Group(
             mk_checkbox(options),
             name=name,
-            hx_post=f'/{name.lower()}'),
+            hx_post=f'/{name.lower()}' if canValidateInline else None),
         Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
 def trueFalseRadioTemplate(label, name, error_msg=None):

--- a/src/mlm_form/validation.py
+++ b/src/mlm_form/validation.py
@@ -3,6 +3,11 @@ from stac_model.output import MLMClassification, ModelOutput, ModelResult
 from stac_model.schema import MLModelProperties
 from pydantic import TypeAdapter, ValidationError
 
+# TODO try to get these from pystac...
+model_asset_roles = ['mlm:model', 'mlm:weights', 'mlm:checkpoint']
+model_asset_implicit_roles = ['mlm:model']
+model_asset_artifact_types = ['torch.save', 'torch.jit.script', 'torch.export', 'torch.compile']
+
 def create_validation_function(model_class, field_name, user_friendly_message):
     def validation_function(value):
         error = validate_single_field(model_class, field_name, value)


### PR DESCRIPTION
since individual asset fields can't be validated directly by pystac, introduced a `canValidateInline` param to control templates to disable direct POST requests when the input changes