### PR TITLE
fix(EWT-1384): visual/ux cleanup for mlm-form

### DIFF
--- a/src/mlm_form/styles.py
+++ b/src/mlm_form/styles.py
@@ -1,0 +1,7 @@
+main_element_style = "padding-left: 25px;"
+
+control_container_style = "display: flex; flex-direction: column; align-items: flex-start;"
+
+text_input_style = "width: 400px; text-align: center;"
+
+select_input_style = "width: 400px;"

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -1,19 +1,23 @@
 from fasthtml.common import *
+import json
+
+from .styles import *
+from .validation import *
 
 ######################
 ### HTML Templates ###
 ######################
 
 def inputTemplate(label, name, val, error_msg=None, input_type='text', canValidateInline=True):
-    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
-               Label(label),
-               Input(name=name,type=input_type,value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style="width: 400px; text-align: center;"),
+    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
+               labelDecoratorTemplate(Label(label), name in model_required_keys),
+               Input(name=name,type=input_type,value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
                Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
 def inputListTemplate(label, name, values=[None, None, None, None], error_msg=None, input_type='number'):
-    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
-        Label(label),
-        Div(style="display: flex; gap: 20px; justify-content: center; width: 100%; max-width: 600px;")(
+    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
+        labelDecoratorTemplate(Label(label), name in model_required_keys),
+        Div(style="display: flex; gap: 20px; justify-content: flex-start; width: 100%; max-width: 600px;")(
             *[
                 Input(name=f'{name.lower()}_{i+1}', id=f'{name.lower()}_{i+1}',
                       placeholder=f"Enter {label} {i+1}", type=input_type, value=val,
@@ -30,22 +34,23 @@ def mk_opts(nm, cs):
         *map(Option, cs))
 
 def mk_checkbox(options):
-    return Div(style="display: flex; flex-direction: column; align-items: flex-start;")(
+    return Div(style=control_container_style)(
         *[Div(CheckboxX(id=option, label=option), style="width: 100%;") for option in options]
     )
 
 def selectEnumTemplate(label, options, name, error_msg=None, canValidateInline=True):
-    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
-        Label(label),
+    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
+        labelDecoratorTemplate(Label(label), name in model_required_keys),
         Select(
             *mk_opts(name, options),
             name=name,
-            hx_post=f'/{name.lower()}' if canValidateInline else None),
+            hx_post=f'/{name.lower()}' if canValidateInline else None,
+            style=select_input_style),
         Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
 def selectCheckboxTemplate(label, options, name, error_msg=None, canValidateInline=True):
-    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style="display: flex; flex-direction: column; align-items: center;")(
-        Label(label),
+    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
+        labelDecoratorTemplate(Label(label), name in model_required_keys),
         Group(
             mk_checkbox(options),
             name=name,
@@ -54,7 +59,7 @@ def selectCheckboxTemplate(label, options, name, error_msg=None, canValidateInli
 
 def trueFalseRadioTemplate(label, name, error_msg=None):
     return Div(
-        Label(label),
+        labelDecoratorTemplate(Label(label), name in model_required_keys),
         Div(
             Input(type="radio", name=name, value="true"),
             Label("True", for_=name),
@@ -63,26 +68,24 @@ def trueFalseRadioTemplate(label, name, error_msg=None):
             style="display: flex; flex-direction: row; align-items: center;"
         ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
-        style="display: flex; flex-direction: column; align-items: center;"
+        style=f'{control_container_style} margin-bottom: 15px;'
     )
 
 def modelInputTemplate(label, name, error_msg=None):
     return Div(
-        Label(label),
+        labelDecoratorTemplate(H4(label, style="margin-left: -30px;"), name in model_required_keys),
         Div(
             Label("Name"),
-            Input(type="text", name=f"{name}[name]"),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
+            Input(type="text", name=f"{name}[name]", style=text_input_style)
         ),
         Div(
             Label("Bands"),
-            Input(type="text", name=f"{name}[bands]"),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
+            Input(type="text", name=f"{name}[bands]", style=text_input_style),
         ),
         Div(
             Label("Norm by Channel"),
             CheckboxX(name=f"{name}[norm_by_channel]"),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
+            style="margin-bottom: 15px;"
         ),
         Div(
             Label("Norm Type"),
@@ -98,14 +101,13 @@ def modelInputTemplate(label, name, error_msg=None):
                 Option("type-mask", value="type-mask"),
                 Option("relative", value="relative"),
                 Option("inf", value="inf"),
-                name=f"{name}[norm_type]"
+                name=f"{name}[norm_type]",
+                style=select_input_style
             ),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
         ),
         Div(
             Label("Norm Clip"),
-            Input(type="text", name=f"{name}[norm_clip]"),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
+            Input(type="text", name=f"{name}[norm_clip]", style=text_input_style),
         ),
         Div(
             Label("Resize Type"),
@@ -121,20 +123,35 @@ def modelInputTemplate(label, name, error_msg=None):
                 Option("interpolation-max", value="interpolation-max"),
                 Option("wrap-fill-outliers", value="wrap-fill-outliers"),
                 Option("wrap-inverse-map", value="wrap-inverse-map"),
-                name=f"{name}[resize_type]"
+                name=f"{name}[resize_type]",
+                style=select_input_style
             ),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
         ),
         Div(
             Label("Statistics"),
-            Input(type="text", name=f"{name}[statistics]"),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
+            Input(type="text", name=f"{name}[statistics]", style=text_input_style),
         ),
         Div(
             Label("Pre Processing Function"),
-            Input(type="text", name=f"{name}[pre_processing_function]"),
-            style="display: flex; flex-direction: column; align-items: flex-start;"
+            Input(type="text", name=f"{name}[pre_processing_function]", style=text_input_style),
         ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
-        style="display: flex; flex-direction: column; align-items: center;"
+        style=f'{control_container_style} margin-left: 30px;'
     )
+
+def labelDecoratorTemplate(label, isRequired):
+    required_indicator = Span('*', style="color: red; margin-right: 5px;")
+    return Div(
+        required_indicator if isRequired else None,
+        label,
+        style="display: flex;"
+    )
+
+def outputTemplate(id):
+    return Div(
+        Div(id=id, style="position: fixed; right: 50px; width: 500px;"),
+        style="position: relative;"
+    )
+
+def prettyJsonTemplate(obj):
+    return Pre(json.dumps(obj, indent = 4), style="margin-top: 25px; width: 100%;")

--- a/src/mlm_form/validation.py
+++ b/src/mlm_form/validation.py
@@ -8,6 +8,23 @@ model_asset_roles = ['mlm:model', 'mlm:weights', 'mlm:checkpoint']
 model_asset_implicit_roles = ['mlm:model']
 model_asset_artifact_types = ['torch.save', 'torch.jit.script', 'torch.export', 'torch.compile']
 
+# possibly fraught to use these keys in all inputs, ideally the input would
+# be aware of both the schema and key name that it's operating on.
+# in practice, model assets don't have any required keys so this works fine.
+model_required_keys = [
+    'shape',
+    'model_name',
+    'architecture',
+    'framework',
+    'framework_version',
+    'accelerator',
+    'accelerator_summary',
+    'file_size',
+    'memory_size',
+    'pretrained_source',
+    'total_parameters'
+]
+
 def create_validation_function(model_class, field_name, user_friendly_message):
     def validation_function(value):
         error = validate_single_field(model_class, field_name, value)


### PR DESCRIPTION
- removed setting text input value to `None`, it was putting the literal string "None" into the UI
- removed direct validation endpoint for `accelerator`, it was replacing the select input with a text input. since the value is selected from a list, direct validation is not needed
- added some shared styles for positioning the form, align controls left, etc
- added template for the output container to make sure its position is fixed as the page scrolls
- added pretty-printing of output JSON
- added "*" indicator next to labels for required inputs