### PR TITLE
fix(EWT-1384): improve error display

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ def submit(d: dict):
 
         errors = {k: v for k, v in errors.items() if v is not None}
 
-        return *[Div(error, style='color: red;') for error in errors.values()], prettyJsonTemplate(d)
+        return *[error_template(error) for error in errors.values()], prettyJsonTemplate(d)
 
     return Div("Please fill in all required fields before submitting.", style='color: red;'), prettyJsonTemplate(d)
 
@@ -173,7 +173,7 @@ def submit_asset(d: dict):
     try:
         validation_result = pystac.validation.validate(dummy_item)
     except pystac.errors.STACValidationError as e:
-        return Div(e, style='color: red;'), prettyJsonTemplate(d)
+        return error_template(e), prettyJsonTemplate(d)
     
     return prettyJsonTemplate(d)
 

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -12,7 +12,7 @@ def inputTemplate(label, name, val, error_msg=None, input_type='text', canValida
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
                labelDecoratorTemplate(Label(label), name in model_required_keys),
                Input(name=name,type=input_type,value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
-               Div(f'{error_msg}', style='color: red;') if error_msg else None)
+               error_template(f'{error_msg}') if error_msg else None)
 
 def inputListTemplate(label, name, values=[None, None, None, None], error_msg=None, input_type='number'):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
@@ -25,7 +25,7 @@ def inputListTemplate(label, name, values=[None, None, None, None], error_msg=No
                 for i, val in enumerate(values)
             ]
         ),
-        Div(f'{error_msg}', style='color: red;') if error_msg else None
+        error_template(f'{error_msg}') if error_msg else None
     )
 
 def mk_opts(nm, cs):
@@ -46,7 +46,7 @@ def selectEnumTemplate(label, options, name, error_msg=None, canValidateInline=T
             name=name,
             hx_post=f'/{name.lower()}' if canValidateInline else None,
             style=select_input_style),
-        Div(f'{error_msg}', style='color: red;') if error_msg else None)
+        error_template(f'{error_msg}') if error_msg else None)
 
 def selectCheckboxTemplate(label, options, name, error_msg=None, canValidateInline=True):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
@@ -55,7 +55,7 @@ def selectCheckboxTemplate(label, options, name, error_msg=None, canValidateInli
             mk_checkbox(options),
             name=name,
             hx_post=f'/{name.lower()}' if canValidateInline else None),
-        Div(f'{error_msg}', style='color: red;') if error_msg else None)
+        error_template(f'{error_msg}') if error_msg else None)
 
 def trueFalseRadioTemplate(label, name, error_msg=None):
     return Div(
@@ -67,7 +67,7 @@ def trueFalseRadioTemplate(label, name, error_msg=None):
             Label("False", for_=name),
             style="display: flex; flex-direction: row; align-items: center;"
         ),
-        Div(f'{error_msg}', style='color: red;') if error_msg else None,
+        error_template(f'{error_msg}') if error_msg else None,
         style=f'{control_container_style} margin-bottom: 15px;'
     )
 
@@ -135,7 +135,7 @@ def modelInputTemplate(label, name, error_msg=None):
             Label("Pre Processing Function"),
             Input(type="text", name=f"{name}[pre_processing_function]", style=text_input_style),
         ),
-        Div(f'{error_msg}', style='color: red;') if error_msg else None,
+        error_template(f'{error_msg}') if error_msg else None,
         style=f'{control_container_style} margin-left: 30px;'
     )
 
@@ -155,3 +155,6 @@ def outputTemplate(id):
 
 def prettyJsonTemplate(obj):
     return Pre(json.dumps(obj, indent = 4), style="margin-top: 25px; width: 100%;")
+    
+def error_template(msg):
+    return  Div(msg, style='color: red; white-space: pre-wrap; margin-left: 10px; margin-bottom: 15px; text-indent: -10px;')

--- a/src/mlm_form/validation.py
+++ b/src/mlm_form/validation.py
@@ -29,7 +29,7 @@ def create_validation_function(model_class, field_name, user_friendly_message):
     def validation_function(value):
         error = validate_single_field(model_class, field_name, value)
         if error:
-            return f"{user_friendly_message} {error}"
+            return f'{user_friendly_message}\n{error}'
         return None
     return validation_function
 
@@ -40,7 +40,11 @@ def validate_single_field(model_class, field_name, value):
         adapter.validate_python(value)
         return None  # Return None if validation passes
     except ValidationError as e:
-        return f"Error for field '{field_name}': {e}"  # Return error message if validation fails
+        return humanize_validation_error(e)  # Return error message if validation fails
+
+def humanize_validation_error(validation_error):
+    messages = [e['msg'] for e in validation_error.errors()]
+    return '\n'.join(list(dict.fromkeys(messages)))
 
 # Validation functions generated using the factory function
 


### PR DESCRIPTION
simplifies the validation errors we get from `pydantic` into more human-readable messages

was not able to find a way to programmatically parse out a smaller message from `pystac`, so these messages are shown as-is