### PR TITLE
Correctly preserve asset form state when switching back and forth between pages while maintaining STAC MLM JSON format in viewer

### DIFF
--- a/src/mlm_form/make_item.py
+++ b/src/mlm_form/make_item.py
@@ -113,6 +113,33 @@ def construct_ml_model_properties(d: Dict[str, Any]) -> MLModelProperties:
 
     return ml_model_meta
 
+def construct_assets(d: Dict[str, Any]) -> Dict[str, pystac.Asset]:
+    """Creates the assets for the STAC item.
+
+    This function takes the payload from the form input and constructs the
+    assets for the STAC item. The assets are the model file and any other
+    files that are needed to run the model.
+
+    Args:
+        d (Dict[str, Any]): The payload from the form with all item property info.
+
+    Returns:
+        Dict[str, pystac.Asset]: The assets for the STAC item.
+    """
+    assets = {}
+    required_keys = ['title', 'model_file', 'type', 'roles', 'mlm:artifact_type']
+    if d and all(key in d and d[key] is not None for key in required_keys):
+        # TODO correct mlm_ > mlm:
+        model_file = pystac.Asset(
+            title=d.get('title'),
+            href=d.get('model_file'),
+            media_type=d.get('type'),
+            roles=d.get('roles'),
+            extra_fields={"mlm_artifact_type": d.get('mlm:artifact_type'),}
+        )
+        assets["model"] = model_file
+    return assets
+
 def create_pystac_item(ml_model_meta: MLModelProperties, assets: Dict[str, pystac.Asset], self_href="./item.json") -> pystac.Item:
     """Creates stac item metadata and extends it with MLM specific properties.
 

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -101,21 +101,28 @@ def modelInputTemplate(label, name, error_msg=None):
             style="margin-bottom: 15px;"
         ),
         selectEnumTemplate("Normalization Type", normalize_type_values,
-            f"{name}_norm_type", error_msg=None, canValidateInline=True),
+            f"{name}_norm_type", error_msg=None, canValidateInline=False),
         Div(
             Label("Norm Clip"),
             Input(type="text", name=f"{name}_norm_clip", style=text_input_style),
         ),
         selectEnumTemplate("Resize Type", resize_type_values,
             f"{name}_resize_type", error_msg=None, canValidateInline=True),
+        # TODO this should be made dynamic so that users can create a new field for a statistic and
+        # then enter an N length list of values for that statistic similar to 
+        # https://gallery.fastht.ml/start_simple/sqlite_todo/code
         Div(
-            Label("Statistics"),
-            Input(type="text", name=f"{name}_statistics", style=text_input_style),
+        Label("Mean Statistic (currently you must enter a single comma separated list of values)"),
+        Input(type="text", name=f"{name}_mean", style=text_input_style),
         ),
         Div(
-            Label("Pre Processing Function"),
-            Input(type="text", name=f"{name}_pre_processing_function", style=text_input_style),
+        Label("Std Statistic (currently you must enter a single comma separated list of values)"),
+        Input(type="text", name=f"{name}_std", style=text_input_style),
         ),
+        # Div(
+        #     Label("Pre Processing Function"),
+        #     Input(type="text", name=f"{name}_pre_processing_function", style=text_input_style),
+        # ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
         style=f'{control_container_style} margin-left: 30px;'
     )
@@ -130,7 +137,7 @@ def modelOutputTemplate(label, name, error_msg=None):
             Input(type="text", name=f"{name}_name", style=text_input_style)
         ),
         # TODO disabling this because we only work with models tha accept single outputs for now but
-        # this should be flippe don and made working in the future
+        # this should be flipped on and made working in the future
         #selectCheckboxTemplate(label="Tasks", options=tasks, name=f"{name}_tasks", canValidateInline=False),
         inputListTemplate(label="Shape", name=f"{name}_shape", error_msg=None, input_type='number'),
         inputListTemplate(label="Dimension Order", name=f"{name}_dim_order", error_msg=None, input_type='text'),
@@ -144,10 +151,10 @@ def modelOutputTemplate(label, name, error_msg=None):
         Label("Categories (currently you must enter a single comma separated list of categories)"),
         Input(type="text", name=f"{name}_classes", style=text_input_style),
         ),
-        Div(
-            Label("Post Processing Function"),
-            Input(type="text", name=f"{name}_pre_processing_function", style=text_input_style),
-        ),
+        # Div(
+        #     Label("Post Processing Function"),
+        #     Input(type="text", name=f"{name}_pre_processing_function", style=text_input_style),
+        # ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
         style=f'{control_container_style} margin-left: 30px;'
     )

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -167,7 +167,7 @@ def labelDecoratorTemplate(label, isRequired):
         style="display: flex;"
     )
 
-def outputTemplate(session_result_d):
+def outputTemplate():
     return Div(
         Div(id="result", style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;"),
         style="position: relative;"

--- a/src/mlm_form/validation.py
+++ b/src/mlm_form/validation.py
@@ -50,7 +50,6 @@ validate_framework_version = create_validation_function(MLModelProperties, "fram
 validate_accelerator = create_validation_function(MLModelProperties, "accelerator", "Please enter a valid accelerator.")
 validate_accelerator_constrained = create_validation_function(MLModelProperties, "accelerator_constrained", "Please enter a valid boolean value for accelerator_constrained.")
 validate_accelerator_summary = create_validation_function(MLModelProperties, "accelerator_summary", "Please enter a valid accelerator summary.")
-validate_file_size = create_validation_function(MLModelProperties, "file_size", "Please enter a valid file size.")
 validate_memory_size = create_validation_function(MLModelProperties, "memory_size", "Please enter a valid memory size.")
 validate_pretrained = create_validation_function(MLModelProperties, "pretrained", "Please enter a valid boolean value for pretrained.")
 validate_pretrained_source = create_validation_function(MLModelProperties, "pretrained_source", "Please enter a valid pretrained source.")

--- a/src/mlm_form/validation.py
+++ b/src/mlm_form/validation.py
@@ -41,7 +41,6 @@ def humanize_validation_error(validation_error):
     return '\n'.join(list(dict.fromkeys(messages)))
 
 # Validation functions generated using the factory function
-
 validate_model_name = create_validation_function(MLModelProperties, "name", "Please enter a valid model name.")
 validate_architecture = create_validation_function(MLModelProperties, "architecture", "Please enter a valid model architecture.")
 validate_tasks = create_validation_function(MLModelProperties, "tasks", "Please enter a valid set of tasks.")


### PR DESCRIPTION
I can preserve state when switching pages if I use this commit: https://github.com/wherobots/mlm-form/commit/eb24d1f725a545f15196df76a03787f6e6eb1a65

But when I introduce the stac formatted json, the key names differ from the fasthtml route names and the name ids of the fasthtml elements. So I tried to add two keys to the session state dict: `stac_format_d` and `form_format_d`. Somehow this breaks session state. The session object appears to be used when not switching pages but the session object gets cleared when I switch pages. I have added breakpoints to see if session.clear() is being calle din my code but it is not which makes me think something is happening upstream in FastHTML.
