### PR TITLE
revamp app to refresh whole page, support cascade dropdown for norm typ and statistics

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ def submit(session, d: dict):
     ml_model_metadata = construct_ml_model_properties(d)
     assets = construct_assets(session['stac_format_d'].get('assets'))
     item = create_pystac_item(ml_model_metadata, assets)
-    return session_form(session), prettyJsonTemplate(item)
+    return prettyJsonTemplate(item)
 
 roles = [role for role in model_asset_roles if role not in model_asset_implicit_roles]
 

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def session_form(session, submitOnLoad=False):
     session.setdefault('form_format_d', {})
     result = session.get('form_format_d', {})
     trigger = "input delay:200ms, load" if submitOnLoad and result else "input delay:200ms"
-    session_form = Form(hx_post='/submit', hx_target="#page", hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
+    session_form = Form(hx_post='/submit', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
                     inputTemplate(label="Model Name", name="model_name", placeholder="A unique identifier for your model", val='', input_type='text'),
                     inputTemplate(label="Architecture", name="architecture", placeholder="A recognizable name for the model architecture", val='', input_type='text'),
                     selectCheckboxTemplate(label="Tasks", options=tasks, name="tasks", canValidateInline=False),

--- a/main.py
+++ b/main.py
@@ -61,7 +61,8 @@ def form_format_to_stac_format_input(d):
     d['mlm_output_classes'] = [item.strip() for item in d.get('mlm_output_classes', '').split(',')]
     d['mlm_input_mean'] = [float(item.strip()) if item != '' else [''] for item in d.get('mlm_input_mean', '').split(',')]
     d['mlm_input_std'] = [float(item.strip()) if item != '' else [''] for item in d.get('mlm_input_std', '').split(',')]
-    d['mlm_input_bands'] = [item.strip() if item != '' else [''] for item in d.get('mlm_input_bands', '').split(',')]
+    d['mlm_input_min'] = [float(item.strip()) if item != '' else [''] for item in d.get('mlm_input_min', '').split(',')]
+    d['mlm_input_max'] = [float(item.strip()) if item != '' else [''] for item in d.get('mlm_input_max', '').split(',')]
     # from the fasthtml discord https://discordapp.com/channels/689892369998676007/1247700012952191049/1273789690691981412
     # this might change past version 0.4.4 it seems pretty hacky
     d['tasks'] = [task for task in tasks if d.pop(task, None)]

--- a/main.py
+++ b/main.py
@@ -91,6 +91,47 @@ def submit(session, d: dict):
     item = create_pystac_item(ml_model_metadata, assets)
     return prettyJsonTemplate(item)
 
+@app.post('/get_stats_input_boxes')
+def get_stats_input_boxes(mlm_input_norm_type: str):
+    if mlm_input_norm_type == 'z-score':
+        return  (Div(
+                Label("Mean Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_mean", id=f"mlm_input_mean",
+                    placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
+                                            1199.47283961, 1999.79090914, 2369.22292565,
+                                            2296.82608323, 732.08340178, 12.11327804,
+                                            1819.01027855, 1118.92391149, 2594.14080798''',
+                                            style=text_input_style),
+            ),
+            Div(
+                Label("Std Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_std", id=f"mlm_input_std",
+                    placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
+                                        593.75055589,
+                                        566.4170017,
+                                        861.18399006,
+                                        1086.63139075,
+                                        1117.98170791,
+                                        404.91978886,
+                                        4.77584468,
+                                        1002.58768311,
+                                        761.30323499,
+                                        1231.58581042''',
+                                        style=text_input_style)
+
+            ))
+    elif mlm_input_norm_type == 'min-max':
+        return  (Div(
+                Label("Min Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_min", id=f"mlm_input_min",
+                    placeholder='''e.g. ....''', style=text_input_style)),
+                Div(
+                Label("Max Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_max", id=f"mlm_input_max",
+                    placeholder='''e.g. ....''', style=text_input_style)))
+    else:
+        return None
+
 roles = [role for role in model_asset_roles if role not in model_asset_implicit_roles]
 
 # helper function to render out the session form

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import pystac
 import copy
 
-app, rt = fast_app(hdrs=(picolink), sess_path='/home/rave/mlm_form')
+app, rt = fast_app(hdrs=(picolink))
 
 @app.get('/')
 def homepage(session):

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def homepage(session):
             ),
             Grid(
                 session_form(session, submitOnLoad=True),
-                outputTemplate()
+                id="page"
             ),
             style=main_element_style
         )
@@ -102,7 +102,7 @@ def session_form(session, submitOnLoad=False):
     session.setdefault('form_format_d', {})
     result = session.get('form_format_d', {})
     trigger = "input delay:200ms, load" if submitOnLoad and result else "input delay:200ms"
-    session_form = Form(hx_post='/submit', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
+    session_form = Form(hx_post='/submit', hx_target='#page', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
                     inputTemplate(label="Model Name", name="model_name", placeholder="A unique identifier for your model", val='', input_type='text'),
                     inputTemplate(label="Architecture", name="architecture", placeholder="A recognizable name for the model architecture", val='', input_type='text'),
                     selectCheckboxTemplate(label="Tasks", options=tasks, name="tasks", canValidateInline=False),

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ def submit(session, d: dict):
     ml_model_metadata = construct_ml_model_properties(d)
     assets = construct_assets(session['stac_format_d'].get('assets'))
     item = create_pystac_item(ml_model_metadata, assets)
-    return Div("Please fill in all required fields before submitting.", style='color: red;'), prettyJsonTemplate(item)
+    return session_form(session), Div("Please fill in all required fields before submitting.", style='color: red;'), prettyJsonTemplate(item)
 
 roles = [role for role in model_asset_roles if role not in model_asset_implicit_roles]
 
@@ -102,7 +102,7 @@ def session_form(session, submitOnLoad=False):
     session.setdefault('form_format_d', {})
     result = session.get('form_format_d', {})
     trigger = "input delay:200ms, load" if submitOnLoad and result else "input delay:200ms"
-    session_form = Form(hx_post='/submit', hx_target='#result', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
+    session_form = Form(hx_post='/submit', hx_target="#page", hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
                     inputTemplate(label="Model Name", name="model_name", placeholder="A unique identifier for your model", val='', input_type='text'),
                     inputTemplate(label="Architecture", name="architecture", placeholder="A recognizable name for the model architecture", val='', input_type='text'),
                     selectCheckboxTemplate(label="Tasks", options=tasks, name="tasks", canValidateInline=False),
@@ -123,56 +123,11 @@ def session_form(session, submitOnLoad=False):
                     trueFalseRadioTemplate(label="Accelerator constrained", name="accelerator_constrained"),
                     inputTemplate(label="Accelerator Summary", name="accelerator_summary", placeholder='A description for the accelerator, e.g. "Nvidia A100"', val='', input_type='text'),
                     inputTemplate(label="Accelerator Count", name="accelerator_count", val=1, input_type='number'),
-                    modelInputTemplate(label="MLM Input", name="mlm_input"),
+                    modelInputTemplate(label="MLM Input", name="mlm_input", form_data=result),
                     modelOutputTemplate(label="MLM Output", name="mlm_output"),
                 )
     fill_form(session_form, result)
     return session_form
-
-@app.get('/get_statistics')
-def update_statistics_by_norm(mlm_input_norm_type: str):
-    if mlm_input_norm_type == 'none':
-        return Div(name='statistics')
-    elif mlm_input_norm_type == 'z-score':
-        return  Div(Div(
-                Label("Mean Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_mean", 
-                    placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
-                                            1199.47283961, 1999.79090914, 2369.22292565,
-                                            2296.82608323, 732.08340178, 12.11327804,
-                                            1819.01027855, 1118.92391149, 2594.14080798''',
-                                            style=text_input_style),
-            ),
-            Div(
-                Label("Std Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_std", 
-                    placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
-                                        593.75055589,
-                                        566.4170017,
-                                        861.18399006,
-                                        1086.63139075,
-                                        1117.98170791,
-                                        404.91978886,
-                                        4.77584468,
-                                        1002.58768311,
-                                        761.30323499,
-                                        1231.58581042''',
-                                        style=text_input_style),
-
-            ), name='statistics')
-    elif mlm_input_norm_type == 'min-max':
-        return  Div(
-                Div(
-                Label("Min Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_min", 
-                    placeholder='''e.g. ....''', style=text_input_style)),
-                Div(
-                Label("Max Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_max", 
-                    placeholder='''e.g. ....''', style=text_input_style)),
-                name='statistics')
-    else:
-        return Div(name='statistics')
 
 def session_asset_form(session, submitOnLoad=False):
     session.setdefault('stac_format_d', {})

--- a/main.py
+++ b/main.py
@@ -91,47 +91,6 @@ def submit(session, d: dict):
     item = create_pystac_item(ml_model_metadata, assets)
     return prettyJsonTemplate(item)
 
-@app.post('/get_stats_input_boxes')
-def get_stats_input_boxes(mlm_input_norm_type: str):
-    if mlm_input_norm_type == 'z-score':
-        return  (Div(
-                Label("Mean Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_mean", id=f"mlm_input_mean",
-                    placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
-                                            1199.47283961, 1999.79090914, 2369.22292565,
-                                            2296.82608323, 732.08340178, 12.11327804,
-                                            1819.01027855, 1118.92391149, 2594.14080798''',
-                                            style=text_input_style),
-            ),
-            Div(
-                Label("Std Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_std", id=f"mlm_input_std",
-                    placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
-                                        593.75055589,
-                                        566.4170017,
-                                        861.18399006,
-                                        1086.63139075,
-                                        1117.98170791,
-                                        404.91978886,
-                                        4.77584468,
-                                        1002.58768311,
-                                        761.30323499,
-                                        1231.58581042''',
-                                        style=text_input_style)
-
-            ))
-    elif mlm_input_norm_type == 'min-max':
-        return  (Div(
-                Label("Min Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_min", id=f"mlm_input_min",
-                    placeholder='''e.g. ....''', style=text_input_style)),
-                Div(
-                Label("Max Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_max", id=f"mlm_input_max",
-                    placeholder='''e.g. ....''', style=text_input_style)))
-    else:
-        return None
-
 roles = [role for role in model_asset_roles if role not in model_asset_implicit_roles]
 
 # helper function to render out the session form
@@ -166,7 +125,7 @@ def session_form(session, submitOnLoad=False):
                     trueFalseRadioTemplate(label="Accelerator constrained", name="accelerator_constrained"),
                     inputTemplate(label="Accelerator Summary", name="accelerator_summary", placeholder='A description for the accelerator, e.g. "Nvidia A100"', val='', input_type='text'),
                     inputTemplate(label="Accelerator Count", name="accelerator_count", val=1, input_type='number'),
-                    modelInputTemplate(label="MLM Input", name="mlm_input", form_data=result),
+                    modelInputTemplate(label="MLM Input", name="mlm_input"),
                     modelOutputTemplate(label="MLM Output", name="mlm_output"),
                 )
     fill_form(session_form, result)

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ def homepage(session):
             ),
             Grid(
                 session_form(session, submitOnLoad=True),
+                outputTemplate(),
                 id="page"
             ),
             style=main_element_style
@@ -87,7 +88,7 @@ def submit(session, d: dict):
     ml_model_metadata = construct_ml_model_properties(d)
     assets = construct_assets(session['stac_format_d'].get('assets'))
     item = create_pystac_item(ml_model_metadata, assets)
-    return session_form(session), Div("Please fill in all required fields before submitting.", style='color: red;'), prettyJsonTemplate(item)
+    return session_form(session), prettyJsonTemplate(item)
 
 roles = [role for role in model_asset_roles if role not in model_asset_implicit_roles]
 
@@ -102,7 +103,7 @@ def session_form(session, submitOnLoad=False):
     session.setdefault('form_format_d', {})
     result = session.get('form_format_d', {})
     trigger = "input delay:200ms, load" if submitOnLoad and result else "input delay:200ms"
-    session_form = Form(hx_post='/submit', hx_target='#page', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
+    session_form = Form(hx_post='/submit', hx_target='#result', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
                     inputTemplate(label="Model Name", name="model_name", placeholder="A unique identifier for your model", val='', input_type='text'),
                     inputTemplate(label="Architecture", name="architecture", placeholder="A recognizable name for the model architecture", val='', input_type='text'),
                     selectCheckboxTemplate(label="Tasks", options=tasks, name="tasks", canValidateInline=False),

--- a/main.py
+++ b/main.py
@@ -129,6 +129,51 @@ def session_form(session, submitOnLoad=False):
     fill_form(session_form, result)
     return session_form
 
+@app.get('/get_statistics')
+def update_statistics_by_norm(mlm_input_norm_type: str):
+    if mlm_input_norm_type == 'none':
+        return Div(name='statistics')
+    elif mlm_input_norm_type == 'z-score':
+        return  Div(Div(
+                Label("Mean Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_mean", 
+                    placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
+                                            1199.47283961, 1999.79090914, 2369.22292565,
+                                            2296.82608323, 732.08340178, 12.11327804,
+                                            1819.01027855, 1118.92391149, 2594.14080798''',
+                                            style=text_input_style),
+            ),
+            Div(
+                Label("Std Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_std", 
+                    placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
+                                        593.75055589,
+                                        566.4170017,
+                                        861.18399006,
+                                        1086.63139075,
+                                        1117.98170791,
+                                        404.91978886,
+                                        4.77584468,
+                                        1002.58768311,
+                                        761.30323499,
+                                        1231.58581042''',
+                                        style=text_input_style),
+
+            ), name='statistics')
+    elif mlm_input_norm_type == 'min-max':
+        return  Div(
+                Div(
+                Label("Min Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_min", 
+                    placeholder='''e.g. ....''', style=text_input_style)),
+                Div(
+                Label("Max Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_max", 
+                    placeholder='''e.g. ....''', style=text_input_style)),
+                name='statistics')
+    else:
+        return Div(name='statistics')
+
 def session_asset_form(session, submitOnLoad=False):
     session.setdefault('stac_format_d', {})
     session.setdefault('form_format_d', {})
@@ -207,4 +252,5 @@ def submit_asset(session, d: dict):
             error_message = f"STACValidationError: {error_message}".replace('\\n', '<br>')
         return error_template(error_message), prettyJsonTemplate(dummy_item.assets['model'].to_dict())
     return prettyJsonTemplate(dummy_item.assets['model'].to_dict())
+
 serve()

--- a/mre.py
+++ b/mre.py
@@ -1,74 +1,36 @@
 from fasthtml.common import *
-import json
-app, rt = fast_app(hdrs=(picolink))
 
-main_element_style = "padding-left: 25px;"
+app, rt = fast_app()
 
-control_container_style = "display: flex; flex-direction: column; align-items: flex-start;"
+chapters = ['ch1', 'ch2', 'ch3']
+lessons = {
+    'ch1': ['lesson1', 'lesson2', 'lesson3'],
+    'ch2': ['lesson4', 'lesson5', 'lesson6'],
+}
 
-text_input_style = "width: 400px; text-align: center;"
+def mk_opts(nm, cs):
+    return (
+        Option(f'-- select {nm} --', disabled='', selected='', value=''),
+        *map(Option, cs))
 
-select_input_style = "width: 400px;"
+@app.get('/get_lesson')
+def get_lesson(chapter: str):
+    return Select(*mk_opts('lesson', lessons[chapter]), name='lesson')
+
 @app.get('/')
-def homepage(session):
+def homepage():
+    chapter_dropdown = Select(
+        *mk_opts('chapter', chapters),
+        name='chapter',
+        get='get_lesson', hx_target='#lesson')
 
-    return Body(
-        Main(
-            Header(
-                H1("Input Text with Session State and Fill Form"),
-            ),
-            Section(
-                Button("Clear Form State", hx_post='/clear_form',
-                       style="margin-top: 20px;", hx_target="#result", hx_swap="innerHTML")
-            ),
-            Grid(
-                session_form(session, submitOnLoad=True),
-                outputTemplate()
-            ),
-            style=main_element_style
-        )
-    )
-
-@app.post('/clear_form')
-def clear_form(session):
-    session.clear()
-    return session_form(session)
-
-
-def prettyJsonTemplate(obj):
-    return Pre(json.dumps(obj, indent = 4), style="margin-top: 25px; width: 100%;")
-
-def outputTemplate():
     return Div(
-        Div(id="result", style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;"),
-        style="position: relative;"
-    )
-
-def inputTemplate(label, name, val, error_msg=None, input_type='text', canValidateInline=False):
-    return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
-               Input(name=name,type=input_type,value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
-               Div(f'{error_msg}', style='color: red;') if error_msg else None)
-
-@app.post('/submit')
-def submit(session, d: dict):
-    session.setdefault('form_data', {})
-    session['form_data'].update(d)
-    return prettyJsonTemplate(d)
-
-# helper function to render out the session form
-# because of the `hx_swap_oob`, this snippet can be returned by any handler and will update the form
-# see https://htmx.org/examples/update-other-content/#oob
-#
-# `submitOnLoad` should be set to true for the initial page load so that the form will
-# auto-submit to populate the results if there is saved state in the session
-def session_form(session, submitOnLoad=False):
-    session.setdefault('form_data', {})
-    result = session.get('form_data', {})
-    trigger = "input delay:200ms, load" if submitOnLoad and result else "input delay:200ms"
-    session_form = Form(hx_post='/submit', hx_target='#result', hx_trigger=trigger, id="session_form", hx_swap_oob="#session_form")(
-                    inputTemplate(label="Text Input. Paste text and then refresh the page. fill form does not keep the pasted value if it is over 122 characters.", val='', name="text_input"),
-                )
-    fill_form(session_form, result)
-    return session_form
+        Div(
+            Label("Chapter:", for_="chapter"),
+            chapter_dropdown),
+        Div(
+            Label("Lesson:", for_="lesson"),
+            Div(Div(id='lesson')),
+    ))
 
 serve()

--- a/mre.py
+++ b/mre.py
@@ -14,7 +14,7 @@ def mk_opts(nm, cs):
         *map(Option, cs))
 
 @app.get('/get_lesson')
-def get_lesson(chapter: str):
+def get_lesson_bug(chapter: str):
     return Select(*mk_opts('lesson', lessons[chapter]), name='lesson')
 
 @app.get('/')

--- a/src/mlm_form/make_item.py
+++ b/src/mlm_form/make_item.py
@@ -34,13 +34,27 @@ def construct_ml_model_properties(d: Dict[str, Any]) -> MLModelProperties:
     )
 
     # Construct MLMStatistic
-    stats = [
+    if d['mlm_input_norm_type'] == 'z-score':
+        stats_vals = zip(d['mlm_input_mean'], d['mlm_input_std'])
+        stats = [
         MLMStatistic.model_construct(
             mean=mean,
             stddev=stddev,
         )
-        for mean, stddev in zip(d['mlm_input_mean'], d['mlm_input_std'])
-    ]
+        for mean, stddev in stats_vals
+        ]
+    elif d['mlm_input_norm_type'] == 'min-max':
+        stats_vals = zip(d['mlm_input_min'], d['mlm_input_max'])
+        stats = [
+        MLMStatistic.model_construct(
+            minimum=minimum,
+            maximum=maximum,
+        )
+        for minimum, maximum in stats_vals
+        ]
+        print('wtf')
+    else:
+        stats= None
 
     # Construct ModelInput
     model_input = ModelInput.model_construct(

--- a/src/mlm_form/make_item.py
+++ b/src/mlm_form/make_item.py
@@ -52,7 +52,6 @@ def construct_ml_model_properties(d: Dict[str, Any]) -> MLModelProperties:
         )
         for minimum, maximum in stats_vals
         ]
-        print('wtf')
     else:
         stats= None
 

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -80,7 +80,8 @@ def trueFalseRadioTemplate(label, name, error_msg=None):
         style=f'{control_container_style} margin-bottom: 15px;'
     )
 
-def modelInputTemplate(label, name, error_msg=None):
+def modelInputTemplate(label, name, form_data, error_msg=None):
+    stats= update_statistics_by_norm(form_data.get('mlm_input_norm_type'))
     return Div(
         labelDecoratorTemplate(H4(label, style="margin-left: -30px;"), name in model_required_keys),
         Div(
@@ -97,14 +98,10 @@ def modelInputTemplate(label, name, error_msg=None):
         selectEnumTemplate("Input Data Type", datatypes,
             f"{name}_data_type", error_msg=None, canValidateInline=False),
         trueFalseRadioTemplate("Normalize Each Channel By Statistics", f"{name}_norm_by_channel", error_msg=None),
-        ## TODO this isn't working route not found
-        Div(
         selectEnumTemplate("Normalization Type", normalize_type_values,
-            f"{name}_norm_type", get="get_statistics", hx_target="#statistics", error_msg=None, canValidateInline=False),
-        Label("Statistics"),
-        Div(Div(id='statistics')),
-        ),
-
+            f"{name}_norm_type", error_msg=None, canValidateInline=False),
+        ## TODO this isn't working route not found
+        stats,
         selectEnumTemplate("Resize Type", resize_type_values,
             f"{name}_resize_type", error_msg=None, canValidateInline=False),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
@@ -149,7 +146,7 @@ def labelDecoratorTemplate(label, isRequired):
 
 def outputTemplate():
     return Div(
-        Div(id="result", style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;"),
+        Div(json, id="result", style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;"),
         style="position: relative;"
     )
 
@@ -158,3 +155,47 @@ def prettyJsonTemplate(obj):
 
 def error_template(msg):
     return  Div(msg, style='color: red; white-space: pre-wrap; margin-left: 10px; margin-bottom: 15px; text-indent: -10px;')
+
+def update_statistics_by_norm(mlm_input_norm_type: str):
+    if mlm_input_norm_type == 'none':
+        return Div(name='statistics')
+    elif mlm_input_norm_type == 'z-score':
+        return  Div(Div(
+                Label("Mean Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_mean", 
+                    placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
+                                            1199.47283961, 1999.79090914, 2369.22292565,
+                                            2296.82608323, 732.08340178, 12.11327804,
+                                            1819.01027855, 1118.92391149, 2594.14080798''',
+                                            style=text_input_style),
+            ),
+            Div(
+                Label("Std Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_std", 
+                    placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
+                                        593.75055589,
+                                        566.4170017,
+                                        861.18399006,
+                                        1086.63139075,
+                                        1117.98170791,
+                                        404.91978886,
+                                        4.77584468,
+                                        1002.58768311,
+                                        761.30323499,
+                                        1231.58581042''',
+                                        style=text_input_style),
+
+            ), name='statistics')
+    elif mlm_input_norm_type == 'min-max':
+        return  Div(
+                Div(
+                Label("Min Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_min", 
+                    placeholder='''e.g. ....''', style=text_input_style)),
+                Div(
+                Label("Max Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_max", 
+                    placeholder='''e.g. ....''', style=text_input_style)),
+                name='statistics')
+    else:
+        return Div(name='statistics')

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -7,18 +7,17 @@ from stac_model.input import NormalizeType, ResizeType
 from typing import get_args
 from stac_model.base import TaskEnum
 
- # idk what Typing.Literal is or why I need to do this :(
+# idk what Typing.Literal is or why I need to do this :(
 normalize_type_values = [value for value in get_args(get_args(NormalizeType)[0])]
 resize_type_values = [value for value in get_args(get_args(ResizeType)[0])]
 tasks = [task.value for task in TaskEnum]
 ######################
 ### HTML Templates ###
 ######################
-
 def inputTemplate(label, name, val, placeholder=None, error_msg=None, input_type='text', canValidateInline=False):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
                labelDecoratorTemplate(Label(label), name in model_required_keys),
-               Input(id=name, name=name,type=input_type, placeholder=placeholder, value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
+               Input(id=name, name=name, type=input_type, placeholder=placeholder, value=f'{val}', hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
                Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
 def inputListTemplate(label, name, placeholder=None, values=[None, None, None, None], error_msg=None, input_type='number', canValidateInline=False):
@@ -46,6 +45,7 @@ def selectEnumTemplate(label, options, name, get=None, hx_target=None, error_msg
         Select(
             *mk_opts(name, options),
             name=name,
+            id=name,
             hx_post=f'/{name.lower()}' if canValidateInline else None,
             get=get,
             hx_target=hx_target,
@@ -63,6 +63,7 @@ def selectCheckboxTemplate(label, options, name, error_msg=None, canValidateInli
         Group(
             mk_checkbox(options),
             name=name,
+            id=name,
             hx_post=f'/{name.lower()}' if canValidateInline else None),
         Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
@@ -70,10 +71,10 @@ def trueFalseRadioTemplate(label, name, error_msg=None):
     return Div(
         labelDecoratorTemplate(Label(label), name in model_required_keys),
         Div(
-            Input(type="radio", name=f"{name}", value="true"),
-            Label("True", for_=name),
-            Input(type="radio", name=f"{name}", value="false"),
-            Label("False", for_=name),
+            Input(type="radio", name=f"{name}", id=f"{name}_true", value="true"),
+            Label("True", for_=f"{name}_true"),
+            Input(type="radio", name=f"{name}", id=f"{name}_false", value="false"),
+            Label("False", for_=f"{name}_false"),
             style="display: flex; flex-direction: row; align-items: center;"
         ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
@@ -86,11 +87,11 @@ def modelInputTemplate(label, name, form_data, error_msg=None):
         labelDecoratorTemplate(H4(label, style="margin-left: -30px;"), name in model_required_keys),
         Div(
             Label("Name"),
-            Input(type="text", name=f"{name}_name", placeholder="A descriptive name for the model input", style=text_input_style)
+            Input(type="text", name=f"{name}_name", id=f"{name}_name", placeholder="A descriptive name for the model input", style=text_input_style)
         ),
         Div(
             Label("Bands (enter a single comma separated list of values)"),
-            Input(type="text", name=f"{name}_bands", placeholder='''e.g. B01,B02,B03,B04,B05,B06,B07,B08,B8A,B09,B10,B11,B12''',
+            Input(type="text", name=f"{name}_bands", id=f"{name}_bands", placeholder='''e.g. B01,B02,B03,B04,B05,B06,B07,B08,B8A,B09,B10,B11,B12''',
                 style=text_input_style),
         ),
         inputListTemplate(label="Input Dimension Sizes", placeholder="Enter Value", name=f"{name}_shape", error_msg=None, input_type='number'),
@@ -115,7 +116,7 @@ def modelOutputTemplate(label, name, error_msg=None):
         labelDecoratorTemplate(H4(label, style="margin-left: -30px;"), name in model_required_keys),
         Div(
             Label("Name"),
-            Input(type="text", name=f"{name}_name", placeholder="A descriptive name of the model output content", style=text_input_style)
+            Input(type="text", name=f"{name}_name", id=f"{name}_name", placeholder="A descriptive name of the model output content", style=text_input_style)
         ),
         # TODO disabling this because we only work with models tha accept single outputs for now but
         # this should be flipped on and made working in the future
@@ -129,7 +130,7 @@ def modelOutputTemplate(label, name, error_msg=None):
         # https://gallery.fastht.ml/start_simple/sqlite_todo/code
         Div(
         Label("Classes (enter a single comma separated list of classes)"),
-        Input(type="text", name=f"{name}_classes", placeholder=''' e.g. "Annual Crop, Forest, Herbaceous Vegetation, Highway, Industrial Buildings, Pasture, Permanent Crop, Residential Buildings, River, SeaLake"''',
+        Input(type="text", name=f"{name}_classes", id=f"{name}_classes", placeholder=''' e.g. "Annual Crop, Forest, Herbaceous Vegetation, Highway, Industrial Buildings, Pasture, Permanent Crop, Residential Buildings, River, SeaLake"''',
                style=text_input_style),
         ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
@@ -163,7 +164,7 @@ def update_statistics_by_norm(mlm_input_norm_type: str):
     elif mlm_input_norm_type == 'z-score':
         return  Div(Div(
                 Label("Mean Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_mean", 
+                Input(type="text", name=f"mlm_input_mean", id=f"mlm_input_mean", 
                     placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
                                             1199.47283961, 1999.79090914, 2369.22292565,
                                             2296.82608323, 732.08340178, 12.11327804,
@@ -172,7 +173,7 @@ def update_statistics_by_norm(mlm_input_norm_type: str):
             ),
             Div(
                 Label("Std Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_std", 
+                Input(type="text", name=f"mlm_input_std", id=f"mlm_input_std", 
                     placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
                                         593.75055589,
                                         566.4170017,
@@ -191,11 +192,11 @@ def update_statistics_by_norm(mlm_input_norm_type: str):
         return  Div(
                 Div(
                 Label("Min Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_min", 
+                Input(type="text", name=f"mlm_input_min", id=f"mlm_input_min", 
                     placeholder='''e.g. ....''', style=text_input_style)),
                 Div(
                 Label("Max Statistic (enter a single comma separated list of values)"),
-                Input(type="text", name=f"mlm_input_max", 
+                Input(type="text", name=f"mlm_input_max", id=f"mlm_input_max", 
                     placeholder='''e.g. ....''', style=text_input_style)),
                 name='statistics')
     else:

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -18,7 +18,7 @@ tasks = [task.value for task in TaskEnum]
 def inputTemplate(label, name, val, placeholder=None, error_msg=None, input_type='text', canValidateInline=False):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
                labelDecoratorTemplate(Label(label), name in model_required_keys),
-               Input(name=name,type=input_type, placeholder=placeholder, value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
+               Input(id=name, name=name,type=input_type, placeholder=placeholder, value=f'{val}',hx_post=f'/{name.lower()}' if canValidateInline else None, style=text_input_style),
                Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
 def inputListTemplate(label, name, placeholder=None, values=[None, None, None, None], error_msg=None, input_type='number', canValidateInline=False):

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -40,13 +40,15 @@ def mk_opts(nm, cs):
         Option(f'-- select {nm} --', disabled='', selected='', value=''),
         *map(lambda c: Option(c, value=c), cs))
 
-def selectEnumTemplate(label, options, name, error_msg=None, canValidateInline=False):
+def selectEnumTemplate(label, options, name, get=None, hx_target=None, error_msg=None, canValidateInline=False):
     return Div(hx_target='this', hx_swap='outerHTML', cls=f"{error_msg if error_msg else 'Valid'}", style=control_container_style)(
         labelDecoratorTemplate(Label(label), name in model_required_keys),
         Select(
             *mk_opts(name, options),
             name=name,
             hx_post=f'/{name.lower()}' if canValidateInline else None,
+            get=get,
+            hx_target=hx_target,
             style=select_input_style),
         Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
@@ -95,36 +97,16 @@ def modelInputTemplate(label, name, error_msg=None):
         selectEnumTemplate("Input Data Type", datatypes,
             f"{name}_data_type", error_msg=None, canValidateInline=False),
         trueFalseRadioTemplate("Normalize Each Channel By Statistics", f"{name}_norm_by_channel", error_msg=None),
+        ## TODO this isn't working route not found
+        Div(
         selectEnumTemplate("Normalization Type", normalize_type_values,
-            f"{name}_norm_type", error_msg=None, canValidateInline=False),
+            f"{name}_norm_type", get="get_statistics", hx_target="#statistics", error_msg=None, canValidateInline=False),
+        Label("Statistics"),
+        Div(Div(id='statistics')),
+        ),
+
         selectEnumTemplate("Resize Type", resize_type_values,
             f"{name}_resize_type", error_msg=None, canValidateInline=False),
-        Div(
-            Label("Mean Statistic (enter a single comma separated list of values)"),
-            Input(type="text", name=f"{name}_mean", 
-                  placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
-                                        1199.47283961, 1999.79090914, 2369.22292565,
-                                        2296.82608323, 732.08340178, 12.11327804,
-                                        1819.01027855, 1118.92391149, 2594.14080798''',
-                                        style=text_input_style),
-        ),
-        Div(
-            Label("Std Statistic (enter a single comma separated list of values)"),
-            Input(type="text", name=f"{name}_std", 
-                  placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
-                                    593.75055589,
-                                    566.4170017,
-                                    861.18399006,
-                                    1086.63139075,
-                                    1117.98170791,
-                                    404.91978886,
-                                    4.77584468,
-                                    1002.58768311,
-                                    761.30323499,
-                                    1231.58581042''',
-                                    style=text_input_style),
-
-        ),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,
         style=f'{control_container_style} margin-left: 30px;'
     )

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -146,12 +146,13 @@ def labelDecoratorTemplate(label, isRequired):
 
 def outputTemplate():
     return Div(
-        Div(json, id="result", style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;"),
+        Div(id="result", style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;"),
         style="position: relative;"
     )
 
 def prettyJsonTemplate(obj):
-    return Pre(json.dumps(obj, indent = 4), style="margin-top: 25px; width: 100%;")
+    return Div(Div(Pre(json.dumps(obj, indent = 4), style="margin-top: 25px; width: 100%;"),
+               style="position: fixed; right: 50px; width: 500px; height: calc(100vh - 250px); overflow: auto;", id='#result'), style="position: relative;")
 
 def error_template(msg):
     return  Div(msg, style='color: red; white-space: pre-wrap; margin-left: 10px; margin-bottom: 15px; text-indent: -10px;')

--- a/src/mlm_form/templates.py
+++ b/src/mlm_form/templates.py
@@ -61,7 +61,6 @@ def selectEnumCascadeTemplate(label, options, name, hx_post, hx_target, error_ms
             hx_post=hx_post,
             hx_target=hx_target,
             hx_swap_oob=f"#{name}",
-            hx_trigger='change',
             style=select_input_style),
         Div(f'{error_msg}', style='color: red;') if error_msg else None)
 
@@ -94,7 +93,42 @@ def trueFalseRadioTemplate(label, name, error_msg=None):
         style=f'{control_container_style} margin-bottom: 15px;'
     )
 
-def modelInputTemplate(label, name, form_data, error_msg=None):
+def statisticsTemplate():
+        return  (Div(
+                Label("Mean Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_mean", id=f"mlm_input_mean",
+                    placeholder='''e.g. 1354.40546513, 1118.24399958, 1042.92983953, 947.62620298,
+                                            1199.47283961, 1999.79090914, 2369.22292565,
+                                            2296.82608323, 732.08340178, 12.11327804,
+                                            1819.01027855, 1118.92391149, 2594.14080798''',
+                                            style=text_input_style),
+            ),
+            Div(
+                Label("Std Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_std", id=f"mlm_input_std",
+                    placeholder='''e.g. 245.71762908, 333.00778264, 395.09249139,
+                                        593.75055589,
+                                        566.4170017,
+                                        861.18399006,
+                                        1086.63139075,
+                                        1117.98170791,
+                                        404.91978886,
+                                        4.77584468,
+                                        1002.58768311,
+                                        761.30323499,
+                                        1231.58581042''',
+                                        style=text_input_style)
+
+            ),
+            Div(
+                Label("Min Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_min", id=f"mlm_input_min",
+                    placeholder='''e.g. ....''', style=text_input_style)),
+                Div(
+                Label("Max Statistic (enter a single comma separated list of values)"),
+                Input(type="text", name=f"mlm_input_max", id=f"mlm_input_max",
+                    placeholder='''e.g. ....''', style=text_input_style)))
+def modelInputTemplate(label, name, error_msg=None):
     return Div(
         labelDecoratorTemplate(H4(label, style="margin-left: -30px;"), name in model_required_keys),
         Div(
@@ -111,9 +145,9 @@ def modelInputTemplate(label, name, form_data, error_msg=None):
         selectEnumTemplate("Input Data Type", datatypes,
             f"{name}_data_type", error_msg=None, canValidateInline=False),
         trueFalseRadioTemplate("Normalize Each Channel By Statistics", f"{name}_norm_by_channel", error_msg=None),
-        selectEnumCascadeTemplate(label="Normalization Type", options=normalize_type_values, name=f"{name}_norm_type", hx_post='/get_stats_input_boxes',
+        selectEnumTemplate(label="Normalization Type. If min-max, fill out min max statistics. If z-score, fill out mean and std statistics.", options=normalize_type_values, name=f"{name}_norm_type",
                                   hx_target='#statistics', error_msg=None),
-        Div(id='statistics'),
+        statisticsTemplate(),
         selectEnumTemplate("Resize Type", resize_type_values,
             f"{name}_resize_type", error_msg=None, canValidateInline=False),
         Div(f'{error_msg}', style='color: red;') if error_msg else None,


### PR DESCRIPTION
I'm unclear if this is just a case of my machine, @sfishel18 indicated page refreshes preserve state.

When I enter input into a textbox field a session id is created. when I enter into another field, a new session id is created and the previous is not found

Setting a breakpoint at `return get_session_by_id(session_id)` shows the following when I edit two fields, instead of using the same session id, a new id is created because the initial id disappears on page refresh

```
session_id
'995b8dad-67d3-4ecd-bb76-3d8ed3d6076a'
session_id
'848e8fe7-3707-4579-a7fb-a773c5abf694'
fasthtml_session
{'session_id': '848e8fe7-3707-4579-a7fb-a773c5abf694'}
```
EDIT
this was caused by me having a hardcoded session path. I think it didn't affect @sfishel18 because he didn't have the path and it defaulted to storing the session in a way that preserved the session on refresh. after removing this hardcode I see the session cookie